### PR TITLE
fix(hashtree): resolve member access via overloaded operator->

### DIFF
--- a/Kernel/Containers/hashtree.ipp
+++ b/Kernel/Containers/hashtree.ipp
@@ -102,7 +102,7 @@ hashtree<K, V>::operator->(void) {
 template <class K, class V>
 inline hashtree<K, V>
 hashtree<K, V>::operator[] (K key) {
-  if (*this->contains (key)) return *this->children (key);
+  if ((*this)->contains (key)) return (*this)->children (key);
   else TM_FAILED ("read-access to non-existent node requested");
 }
 


### PR DESCRIPTION
### Problem

In Arch Linux's latest build, compiling `hashtree.ipp` fails with:  
```plaintext
  error: ‘class hashtree<K, V>’ has no member named ‘contains’
```

### Solution

Fixed by explicitly using (*this)->contains() and (*this)->children() to ensure correct member access via operator->.

### Log 

Also see https://github.com/luozhiya/arch-mogan/actions/runs/14946817328/job/41991193339
